### PR TITLE
[fe][docker][image] specify jdk version explicitly in  fe-ubuntu.Dockerfile

### DIFF
--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
         rm -rf /var/lib/apt/lists/*
 RUN echo "export PATH=/usr/lib/linux-tools/5.15.0-60-generic:$PATH" >> /etc/bash.bashrc && \
         touch /.dockerenv
-ENV JAVA_HOME=/lib/jvm/default-java
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64
 
 WORKDIR $STARROCKS_ROOT
 

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -26,7 +26,7 @@ FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        default-jdk mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic && \
+        openjdk-11-jdk mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
^

`default-jdk` is not intuitive to read. It changes with another ubuntu release version, even the same `ubuntu:22.04`.

check in image
```
root@d253a1acbf3a:/opt/starrocks# apt-cache search --names-only 'openjdk-11-jdk' 
openjdk-11-jdk - OpenJDK Development Kit (JDK)
openjdk-11-jdk-headless - OpenJDK Development Kit (JDK) (headless)
```

Refer to https://launchpad.net/ubuntu/jammy/+package/default-jdk for what's `default-jdk`.

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ x ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [ x ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
